### PR TITLE
feat: Add command-line arguments access

### DIFF
--- a/examples/command_line_args.neon
+++ b/examples/command_line_args.neon
@@ -1,0 +1,19 @@
+// Test script for command-line arguments
+print "Number of arguments:"
+print args.length()
+
+print "Arguments:"
+for (arg in args) {
+    print arg
+}
+
+// Test indexing
+if (args.length() > 0) {
+    print "First argument:"
+    print args[0]
+}
+
+if (args.length() > 1) {
+    print "Second argument:"
+    print args[1]
+}

--- a/examples/test_args_simple.neon
+++ b/examples/test_args_simple.neon
@@ -1,0 +1,1 @@
+print args

--- a/examples/test_math.neon
+++ b/examples/test_math.neon
@@ -1,0 +1,1 @@
+print Math.abs(-5)

--- a/src/compiler/codegen.rs
+++ b/src/compiler/codegen.rs
@@ -126,13 +126,16 @@ impl CodeGenerator {
     fn get_variable_index(&self, name: &str) -> (Option<u32>, bool, bool) {
         // Returns: (index, is_mutable, is_global)
 
-        // Special case: Math and File are built-in globals stored in the VM's globals HashMap
+        // Special case: Math, File, and args are built-in globals stored in the VM's globals HashMap
         // We use sentinel values to signal the VM to look up built-in globals
         if name == "Math" {
             return (Some(u32::MAX), false, true); // u32::MAX = Math
         }
         if name == "File" {
             return (Some(u32::MAX - 1), false, true); // u32::MAX - 1 = File
+        }
+        if name == "args" {
+            return (Some(u32::MAX - 2), false, true); // u32::MAX - 2 = args
         }
 
         // Search in bloq stack from innermost to outermost

--- a/src/compiler/semantic.rs
+++ b/src/compiler/semantic.rs
@@ -49,10 +49,29 @@ impl SemanticAnalyzer {
         };
         let _ = symbol_table.define(file_symbol); // Ignore error since this is initial setup
 
+        // Pre-define args as a built-in global constant (array)
+        // This corresponds to the command-line arguments array that will be available at runtime
+        let args_symbol = Symbol {
+            name: "args".to_string(),
+            kind: SymbolKind::Value,
+            is_mutable: false,
+            scope_depth: 0,
+            location: SourceLocation {
+                offset: 0,
+                line: 0,
+                column: 0,
+            },
+        };
+        let _ = symbol_table.define(args_symbol); // Ignore error since this is initial setup
+
+        let mut type_env = HashMap::new();
+        // Track that args is an Array type for method validation
+        type_env.insert("args".to_string(), "Array".to_string());
+
         SemanticAnalyzer {
             symbol_table,
             errors: Vec::new(),
-            type_env: HashMap::new(),
+            type_env,
         }
     }
 

--- a/src/compiler/tests/codegen.rs
+++ b/src/compiler/tests/codegen.rs
@@ -95,7 +95,7 @@ fn test_end_to_end_execution() {
     "#;
     let bloq = compile_program(program).unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.run_bloq(bloq);
 
     #[cfg(any(test, debug_assertions))]
@@ -119,7 +119,7 @@ fn test_end_to_end_function() {
     "#;
     let bloq = compile_program(program).unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.run_bloq(bloq);
 
     #[cfg(any(test, debug_assertions))]
@@ -148,7 +148,7 @@ fn test_end_to_end_forward_reference() {
     "#;
     let bloq = compile_program(program).unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.run_bloq(bloq);
 
     #[cfg(any(test, debug_assertions))]

--- a/src/compiler/tests/mod.rs
+++ b/src/compiler/tests/mod.rs
@@ -4,3 +4,4 @@ mod parser;
 mod scanner;
 mod semantic;
 mod symbol_table;
+mod test_args_global;

--- a/src/compiler/tests/test_args_global.rs
+++ b/src/compiler/tests/test_args_global.rs
@@ -1,0 +1,29 @@
+#[cfg(test)]
+mod test_args_global {
+    use crate::compiler::semantic::SemanticAnalyzer;
+    use crate::compiler::parser::Parser;
+
+    #[test]
+    fn test_args_is_predefined() {
+        let source = "print args";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().unwrap();
+
+        let mut analyzer = SemanticAnalyzer::new();
+        let result = analyzer.analyze(&ast);
+
+        assert!(result.is_ok(), "args should be predefined as a built-in global");
+    }
+
+    #[test]
+    fn test_args_can_be_accessed() {
+        let source = "val x = args";
+        let mut parser = Parser::new(source);
+        let ast = parser.parse().unwrap();
+
+        let mut analyzer = SemanticAnalyzer::new();
+        let result = analyzer.analyze(&ast);
+
+        assert!(result.is_ok(), "args should be accessible");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,9 @@ fn main() {
     if args.len() == 1 {
         run_repl();
     } else if args.len() >= 2 {
-        run_file(&args[1]);
+        // Pass all arguments after the script path to the script
+        let script_args = args[2..].to_vec();
+        run_file(&args[1], script_args);
     } else {
         exit(64);
     }
@@ -49,7 +51,8 @@ fn print_tagline() {
 fn run_repl() {
     println!("Type 'exit' or Ctrl+C to quit");
 
-    let mut vm = VirtualMachine::new();
+    // REPL has no command-line arguments
+    let mut vm = VirtualMachine::new(Vec::new());
     loop {
         print_prompt();
         let line = read_line();
@@ -83,11 +86,11 @@ fn print_prompt() {
     io::stdout().flush().unwrap();
 }
 
-fn run_file(path: &String) {
+fn run_file(path: &String, args: Vec<String>) {
     println!("Running file: {} ", path);
 
     let source = read_file(path);
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(args);
 
     let result: Result = vm.interpret(source);
     match result {

--- a/src/vm/array_functions.rs
+++ b/src/vm/array_functions.rs
@@ -125,7 +125,7 @@ mod tests {
 
     #[test]
     fn test_array_push() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![Value::Number(1.0), Value::Number(2.0)]);
         let value = Value::Number(3.0);
         let args = vec![array.clone(), value];
@@ -153,7 +153,7 @@ mod tests {
 
     #[test]
     fn test_array_push_to_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
         let value = Value::Number(42.0);
         let args = vec![array.clone(), value];
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_array_push_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
 
         // Too few arguments
@@ -195,7 +195,7 @@ mod tests {
 
     #[test]
     fn test_array_push_on_non_array() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_array = Value::Number(42.0);
         let value = Value::Number(1.0);
         let args = vec![not_array, value];
@@ -207,7 +207,7 @@ mod tests {
 
     #[test]
     fn test_array_pop() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![
             Value::Number(1.0),
             Value::Number(2.0),
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_array_pop_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
         let args = vec![array];
 
@@ -249,7 +249,7 @@ mod tests {
 
     #[test]
     fn test_array_pop_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![Value::Number(1.0)]);
 
         // Too many arguments
@@ -261,7 +261,7 @@ mod tests {
 
     #[test]
     fn test_array_pop_on_non_array() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_array = Value::Number(42.0);
         let args = vec![not_array];
 
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_array_length() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![
             Value::Number(1.0),
             Value::Number(2.0),
@@ -286,7 +286,7 @@ mod tests {
 
     #[test]
     fn test_array_length_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
         let args = vec![array];
 
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn test_array_size_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![])))));
         let result = native_array_size(&mut vm, &[array]).unwrap();
         assert_eq!(result, Value::Number(0.0));
@@ -304,7 +304,7 @@ mod tests {
 
     #[test]
     fn test_array_length_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
 
         // Too many arguments
@@ -316,7 +316,7 @@ mod tests {
 
     #[test]
     fn test_array_length_on_non_array() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_array = Value::Number(42.0);
         let args = vec![not_array];
 
@@ -327,7 +327,7 @@ mod tests {
 
     #[test]
     fn test_array_push_different_types() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![Value::Number(1.0)]);
 
         // Push boolean
@@ -356,7 +356,7 @@ mod tests {
 
     #[test]
     fn test_array_operations_sequence() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::new_array(vec![]);
 
         // Start with empty array
@@ -406,7 +406,7 @@ mod tests {
 
     #[test]
     fn test_array_size_with_elements() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![
             Value::Number(1.0),
             Value::Number(2.0),
@@ -418,7 +418,7 @@ mod tests {
 
     #[test]
     fn test_array_size_no_args() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let result = native_array_size(&mut vm, &[]);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "array.size() requires an array receiver");
@@ -426,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_array_size_wrong_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let result = native_array_size(&mut vm, &[Value::Number(42.0)]);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "size() can only be called on arrays");
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_array_contains_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![
             Value::Number(1.0),
             Value::Number(2.0),
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_array_contains_not_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![
             Value::Number(1.0),
             Value::Number(2.0),
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_array_contains_empty_array() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![])))));
         let result = native_array_contains(&mut vm, &[array, Value::Number(1.0)]).unwrap();
         assert_eq!(result, Value::Boolean(false));
@@ -467,7 +467,7 @@ mod tests {
     #[test]
     fn test_array_contains_string() {
         use crate::common::ObjString;
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let string_val = Value::Object(Rc::new(Object::String(ObjString {
             value: "hello".into(),
         })));
@@ -481,7 +481,7 @@ mod tests {
 
     #[test]
     fn test_array_contains_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let array = Value::Object(Rc::new(Object::Array(Rc::new(RefCell::new(vec![])))));
         let result = native_array_contains(&mut vm, &[array]);
         assert!(result.is_err());
@@ -490,7 +490,7 @@ mod tests {
 
     #[test]
     fn test_array_contains_wrong_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let result = native_array_contains(&mut vm, &[Value::Number(42.0), Value::Number(1.0)]);
         assert!(result.is_err());
         assert_eq!(result.unwrap_err(), "contains() can only be called on arrays");

--- a/src/vm/boolean_functions.rs
+++ b/src/vm/boolean_functions.rs
@@ -26,7 +26,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let bool_val = Value::Boolean(true);
         let args = vec![bool_val];
 
@@ -36,7 +36,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let bool_val = Value::Boolean(false);
         let args = vec![bool_val];
 
@@ -46,7 +46,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_no_args() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![];
 
         let result = native_boolean_to_string(&mut vm, &args);
@@ -59,7 +59,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_wrong_type_number() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(42.0)];
 
         let result = native_boolean_to_string(&mut vm, &args);
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_wrong_type_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![string!("test")];
 
         let result = native_boolean_to_string(&mut vm, &args);
@@ -85,7 +85,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_multiple_true_calls() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         for _ in 0..3 {
             let bool_val = Value::Boolean(true);
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_multiple_false_calls() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         for _ in 0..3 {
             let bool_val = Value::Boolean(false);
@@ -109,7 +109,7 @@ mod tests {
 
     #[test]
     fn test_boolean_to_string_alternating() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let test_cases = vec![
             (true, "true"),

--- a/src/vm/file_functions.rs
+++ b/src/vm/file_functions.rs
@@ -173,7 +173,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_valid_path() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let path = "test.txt";
         let args = vec![Value::Object(Rc::new(Object::String(ObjString {
             value: Rc::from(path),
@@ -194,7 +194,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_wrong_arg_count_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![];
         let result = native_file_constructor(&mut vm, &args);
         assert!(result.is_err());
@@ -203,7 +203,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_wrong_arg_count_two() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Object(Rc::new(Object::String(ObjString {
                 value: Rc::from("test.txt"),
@@ -219,7 +219,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_invalid_type_number() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(42.0)];
         let result = native_file_constructor(&mut vm, &args);
         assert!(result.is_err());
@@ -231,7 +231,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_invalid_type_boolean() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Boolean(true)];
         let result = native_file_constructor(&mut vm, &args);
         assert!(result.is_err());
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_invalid_type_nil() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Nil];
         let result = native_file_constructor(&mut vm, &args);
         assert!(result.is_err());
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_with_relative_path() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let path = "../data/input.txt";
         let args = vec![Value::Object(Rc::new(Object::String(ObjString {
             value: Rc::from(path),
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_file_constructor_with_absolute_path() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let path = "/home/user/data/input.txt";
         let args = vec![Value::Object(Rc::new(Object::String(ObjString {
             value: Rc::from(path),
@@ -301,7 +301,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with some content
         let temp_dir = std::env::temp_dir();
@@ -339,7 +339,7 @@ mod tests {
     fn test_file_read_empty_file() {
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create an empty temporary file
         let temp_dir = std::env::temp_dir();
@@ -376,7 +376,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with Unicode content
         let temp_dir = std::env::temp_dir();
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn test_file_read_file_not_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object with a non-existent path
         let file_obj = Value::new_file("/nonexistent/path/to/file.txt".to_string());
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_file_read_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -447,7 +447,7 @@ mod tests {
 
     #[test]
     fn test_file_read_invalid_receiver_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call read() on a non-File object
         let args = vec![Value::Object(Rc::new(Object::String(ObjString {
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_file_read_invalid_receiver_primitive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call read() on a number
         let args = vec![Value::Number(42.0)];
@@ -482,7 +482,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with multiline content
         let temp_dir = std::env::temp_dir();
@@ -522,7 +522,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with multiline content
         let temp_dir = std::env::temp_dir();
@@ -586,7 +586,7 @@ mod tests {
     fn test_file_read_lines_empty_file() {
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create an empty temporary file
         let temp_dir = std::env::temp_dir();
@@ -624,7 +624,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with a single line (no newline at end)
         let temp_dir = std::env::temp_dir();
@@ -672,7 +672,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with Windows-style line endings
         let temp_dir = std::env::temp_dir();
@@ -731,7 +731,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with Unicode content
         let temp_dir = std::env::temp_dir();
@@ -786,7 +786,7 @@ mod tests {
 
     #[test]
     fn test_file_read_lines_file_not_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object with a non-existent path
         let file_obj = Value::new_file("/nonexistent/path/to/file.txt".to_string());
@@ -804,7 +804,7 @@ mod tests {
 
     #[test]
     fn test_file_read_lines_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -821,7 +821,7 @@ mod tests {
 
     #[test]
     fn test_file_read_lines_invalid_receiver_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call readLines() on a non-File object
         let args = vec![Value::Object(Rc::new(Object::String(ObjString {
@@ -838,7 +838,7 @@ mod tests {
 
     #[test]
     fn test_file_read_lines_invalid_receiver_primitive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call readLines() on a number
         let args = vec![Value::Number(42.0)];
@@ -856,7 +856,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file with empty lines
         let temp_dir = std::env::temp_dir();
@@ -918,7 +918,7 @@ mod tests {
     // Tests for File.write()
     #[test]
     fn test_file_write_success() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file path that doesn't exist yet
         let temp_dir = std::env::temp_dir();
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn test_file_write_empty_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file path that doesn't exist yet
         let temp_dir = std::env::temp_dir();
@@ -982,7 +982,7 @@ mod tests {
 
     #[test]
     fn test_file_write_multiline_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file path that doesn't exist yet
         let temp_dir = std::env::temp_dir();
@@ -1015,7 +1015,7 @@ mod tests {
 
     #[test]
     fn test_file_write_unicode_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file path that doesn't exist yet
         let temp_dir = std::env::temp_dir();
@@ -1051,7 +1051,7 @@ mod tests {
         use std::io::Write;
         use std::fs::File;
 
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a temporary file that already exists
         let temp_dir = std::env::temp_dir();
@@ -1088,7 +1088,7 @@ mod tests {
 
     #[test]
     fn test_file_write_wrong_arg_count_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -1105,7 +1105,7 @@ mod tests {
 
     #[test]
     fn test_file_write_wrong_arg_count_too_many() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -1126,7 +1126,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_content_type_number() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -1144,7 +1144,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_content_type_boolean() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -1162,7 +1162,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_content_type_nil() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object
         let file_obj = Value::new_file("test.txt".to_string());
@@ -1180,7 +1180,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_receiver_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call write() on a non-File object
         let receiver = Value::Object(Rc::new(Object::String(ObjString {
@@ -1201,7 +1201,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_receiver_primitive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Try to call write() on a number
         let receiver = Value::Number(42.0);
@@ -1220,7 +1220,7 @@ mod tests {
 
     #[test]
     fn test_file_write_invalid_directory() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create a File object with a path in a non-existent directory
         let file_obj = Value::new_file("/nonexistent/directory/file.txt".to_string());

--- a/src/vm/functions.rs
+++ b/src/vm/functions.rs
@@ -470,6 +470,18 @@ impl VirtualMachine {
             self.runtime_error("Built-in global 'File' not found");
             return;
         }
+        if index == (u32::MAX - 2) as usize {
+            // This is a request for args from the globals HashMap
+            if let Some(value) = self.globals.get("args") {
+                self.push(value.clone());
+                let frame = self.call_frames.last_mut().unwrap();
+                frame.ip += bits.as_bytes();
+                return;
+            }
+            // If args is not found, this is an internal error
+            self.runtime_error("Built-in global 'args' not found");
+            return;
+        }
 
         // Regular global variables are in the script frame
         // Script frame has slot_start = -1, so globals start at index 0

--- a/src/vm/map_functions.rs
+++ b/src/vm/map_functions.rs
@@ -235,7 +235,7 @@ mod tests {
 
     #[test]
     fn test_map_get_existing_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("name")), string!("Alice"));
         entries.insert(MapKey::Number(OrderedFloat(42.0)), Value::Number(100.0));
@@ -255,7 +255,7 @@ mod tests {
 
     #[test]
     fn test_map_get_nonexistent_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let key = string!("missing");
         let args = vec![map, key];
@@ -266,7 +266,7 @@ mod tests {
 
     #[test]
     fn test_map_size_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let args = vec![map];
 
@@ -276,7 +276,7 @@ mod tests {
 
     #[test]
     fn test_map_size_with_entries() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("a")), Value::Number(1.0));
         entries.insert(MapKey::String(Rc::from("b")), Value::Number(2.0));
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_map_has_existing_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("name")), string!("Alice"));
         let map = Value::new_map(entries);
@@ -303,7 +303,7 @@ mod tests {
 
     #[test]
     fn test_map_has_nonexistent_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let key = string!("missing");
         let args = vec![map, key];
@@ -314,7 +314,7 @@ mod tests {
 
     #[test]
     fn test_map_remove_existing_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("name")), string!("Alice"));
         entries.insert(MapKey::String(Rc::from("age")), Value::Number(30.0));
@@ -349,7 +349,7 @@ mod tests {
 
     #[test]
     fn test_map_remove_nonexistent_key() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let key = string!("missing");
         let args = vec![map, key];
@@ -360,7 +360,7 @@ mod tests {
 
     #[test]
     fn test_map_keys() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("a")), Value::Number(1.0));
         entries.insert(MapKey::Number(OrderedFloat(42.0)), Value::Number(2.0));
@@ -386,7 +386,7 @@ mod tests {
 
     #[test]
     fn test_map_values() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("a")), Value::Number(1.0));
         entries.insert(MapKey::String(Rc::from("b")), Value::Number(2.0));
@@ -411,7 +411,7 @@ mod tests {
 
     #[test]
     fn test_map_entries() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut entries = HashMap::new();
         entries.insert(MapKey::String(Rc::from("name")), string!("Alice"));
         entries.insert(MapKey::Number(OrderedFloat(42.0)), Value::Number(100.0));
@@ -448,7 +448,7 @@ mod tests {
 
     #[test]
     fn test_map_keys_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let args = vec![map];
 
@@ -468,7 +468,7 @@ mod tests {
 
     #[test]
     fn test_map_values_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let args = vec![map];
 
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_map_entries_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let map = Value::new_map(HashMap::new());
         let args = vec![map];
 

--- a/src/vm/math_functions.rs
+++ b/src/vm/math_functions.rs
@@ -127,7 +127,7 @@ mod tests {
 
     #[test]
     fn test_abs_positive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0)];
         let result = native_math_abs(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -135,7 +135,7 @@ mod tests {
 
     #[test]
     fn test_abs_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(-5.0)];
         let result = native_math_abs(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -143,7 +143,7 @@ mod tests {
 
     #[test]
     fn test_abs_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(0.0)];
         let result = native_math_abs(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 0.0);
@@ -151,7 +151,7 @@ mod tests {
 
     #[test]
     fn test_abs_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(-3.14)];
         let result = native_math_abs(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 3.14);
@@ -159,7 +159,7 @@ mod tests {
 
     #[test]
     fn test_abs_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Boolean(true)];
         let result = native_math_abs(&mut vm, &args);
         assert!(result.is_err());
@@ -168,7 +168,7 @@ mod tests {
 
     #[test]
     fn test_abs_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0), Value::Number(3.0)];
         let result = native_math_abs(&mut vm, &args);
         assert!(result.is_err());
@@ -177,7 +177,7 @@ mod tests {
 
     #[test]
     fn test_floor_positive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.7)];
         let result = native_math_floor(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -185,7 +185,7 @@ mod tests {
 
     #[test]
     fn test_floor_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(-5.3)];
         let result = native_math_floor(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), -6.0);
@@ -193,7 +193,7 @@ mod tests {
 
     #[test]
     fn test_floor_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0)];
         let result = native_math_floor(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -201,7 +201,7 @@ mod tests {
 
     #[test]
     fn test_floor_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Nil];
         let result = native_math_floor(&mut vm, &args);
         assert!(result.is_err());
@@ -210,7 +210,7 @@ mod tests {
 
     #[test]
     fn test_ceil_positive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.3)];
         let result = native_math_ceil(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 6.0);
@@ -218,7 +218,7 @@ mod tests {
 
     #[test]
     fn test_ceil_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(-5.7)];
         let result = native_math_ceil(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), -5.0);
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn test_ceil_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0)];
         let result = native_math_ceil(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -234,7 +234,7 @@ mod tests {
 
     #[test]
     fn test_ceil_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Boolean(false)];
         let result = native_math_ceil(&mut vm, &args);
         assert!(result.is_err());
@@ -243,7 +243,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_positive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(16.0)];
         let result = native_math_sqrt(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 4.0);
@@ -251,7 +251,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(0.0)];
         let result = native_math_sqrt(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 0.0);
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(2.0)];
         let result = native_math_sqrt(&mut vm, &args).unwrap();
         assert!((as_number!(result) - 1.4142135623730951).abs() < 1e-10);
@@ -267,7 +267,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(-4.0)];
         let result = native_math_sqrt(&mut vm, &args);
         assert!(result.is_err());
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Nil];
         let result = native_math_sqrt(&mut vm, &args);
         assert!(result.is_err());
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_min_single() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0)];
         let result = native_math_min(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -296,7 +296,7 @@ mod tests {
 
     #[test]
     fn test_min_multiple() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Number(2.0),
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn test_min_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(-5.0),
             Value::Number(-2.0),
@@ -321,7 +321,7 @@ mod tests {
 
     #[test]
     fn test_min_mixed() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Number(-2.0),
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_min_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![];
         let result = native_math_min(&mut vm, &args);
         assert!(result.is_err());
@@ -346,7 +346,7 @@ mod tests {
 
     #[test]
     fn test_min_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Boolean(true),
@@ -359,7 +359,7 @@ mod tests {
 
     #[test]
     fn test_max_single() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(5.0)];
         let result = native_math_max(&mut vm, &args).unwrap();
         assert_eq!(as_number!(result), 5.0);
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_max_multiple() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Number(2.0),
@@ -380,7 +380,7 @@ mod tests {
 
     #[test]
     fn test_max_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(-5.0),
             Value::Number(-2.0),
@@ -392,7 +392,7 @@ mod tests {
 
     #[test]
     fn test_max_mixed() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Number(-2.0),
@@ -405,7 +405,7 @@ mod tests {
 
     #[test]
     fn test_max_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![];
         let result = native_math_max(&mut vm, &args);
         assert!(result.is_err());
@@ -417,7 +417,7 @@ mod tests {
 
     #[test]
     fn test_max_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Nil,
@@ -430,7 +430,7 @@ mod tests {
 
     #[test]
     fn test_min_max_same_value() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![
             Value::Number(5.0),
             Value::Number(5.0),
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_min_max_two_values() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Number(3.0), Value::Number(7.0)];
 
         let min_result = native_math_min(&mut vm, &args).unwrap();
@@ -458,7 +458,7 @@ mod tests {
 
     #[test]
     fn test_sqrt_perfect_squares() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_cases = vec![(1.0, 1.0), (4.0, 2.0), (9.0, 3.0), (25.0, 5.0), (100.0, 10.0)];
 
         for (input, expected) in test_cases {
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn test_floor_ceil_edge_cases() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Test 0.5
         let args = vec![Value::Number(0.5)];

--- a/src/vm/number_functions.rs
+++ b/src/vm/number_functions.rs
@@ -32,7 +32,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(123.0);
         let args = vec![num];
 
@@ -42,7 +42,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(45.67);
         let args = vec![num];
 
@@ -52,7 +52,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(0.0);
         let args = vec![num];
 
@@ -62,7 +62,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_negative_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(-42.0);
         let args = vec![num];
 
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_negative_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(-3.14);
         let args = vec![num];
 
@@ -82,7 +82,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_large_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(1000000.0);
         let args = vec![num];
 
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_small_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(0.001);
         let args = vec![num];
 
@@ -102,7 +102,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_infinity() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(f64::INFINITY);
         let args = vec![num];
 
@@ -112,7 +112,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_negative_infinity() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(f64::NEG_INFINITY);
         let args = vec![num];
 
@@ -122,7 +122,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_nan() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(f64::NAN);
         let args = vec![num];
 
@@ -132,7 +132,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_no_args() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![];
 
         let result = native_number_to_string(&mut vm, &args);
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_wrong_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let args = vec![Value::Boolean(true)];
 
         let result = native_number_to_string(&mut vm, &args);
@@ -158,7 +158,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_scientific_notation() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(1.23e10);
         let args = vec![num];
 
@@ -169,7 +169,7 @@ mod tests {
 
     #[test]
     fn test_number_to_string_very_small() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let num = Value::Number(1.23e-10);
         let args = vec![num];
 

--- a/src/vm/set_functions.rs
+++ b/src/vm/set_functions.rs
@@ -355,7 +355,7 @@ mod tests {
 
     #[test]
     fn test_set_add_new_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Number(42.0);
         let args = vec![set.clone(), element];
@@ -379,7 +379,7 @@ mod tests {
 
     #[test]
     fn test_set_add_duplicate_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(42.0)));
         let set = Value::new_set(elements);
@@ -404,7 +404,7 @@ mod tests {
 
     #[test]
     fn test_set_add_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = string!("hello");
         let args = vec![set.clone(), element];
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_set_add_boolean() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Boolean(true);
         let args = vec![set.clone(), element];
@@ -452,7 +452,7 @@ mod tests {
 
     #[test]
     fn test_set_add_invalid_type() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Nil;
         let args = vec![set, element];
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_set_remove_existing_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(42.0)));
         elements.insert(SetKey::Number(OrderedFloat(100.0)));
@@ -492,7 +492,7 @@ mod tests {
 
     #[test]
     fn test_set_remove_nonexistent_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Number(42.0);
         let args = vec![set, element];
@@ -503,7 +503,7 @@ mod tests {
 
     #[test]
     fn test_set_has_existing_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::String(Rc::from("hello")));
         let set = Value::new_set(elements);
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_set_has_nonexistent_element() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = string!("hello");
         let args = vec![set, element];
@@ -527,7 +527,7 @@ mod tests {
 
     #[test]
     fn test_set_size_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -537,7 +537,7 @@ mod tests {
 
     #[test]
     fn test_set_size_with_elements() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(1.0)));
         elements.insert(SetKey::Number(OrderedFloat(2.0)));
@@ -551,7 +551,7 @@ mod tests {
 
     #[test]
     fn test_set_clear_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set.clone()];
 
@@ -573,7 +573,7 @@ mod tests {
 
     #[test]
     fn test_set_clear_with_elements() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(1.0)));
         elements.insert(SetKey::Number(OrderedFloat(2.0)));
@@ -599,7 +599,7 @@ mod tests {
 
     #[test]
     fn test_set_add_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -610,7 +610,7 @@ mod tests {
 
     #[test]
     fn test_set_remove_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_set_has_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_set_size_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Number(42.0);
         let args = vec![set, element];
@@ -644,7 +644,7 @@ mod tests {
 
     #[test]
     fn test_set_clear_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let element = Value::Number(42.0);
         let args = vec![set, element];
@@ -656,7 +656,7 @@ mod tests {
 
     #[test]
     fn test_set_methods_on_non_set() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_a_set = Value::Number(42.0);
         let element = Value::Number(1.0);
 
@@ -685,7 +685,7 @@ mod tests {
 
     #[test]
     fn test_set_union_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create set1 = {1, 2, 3}
         let mut elements1 = BTreeSet::new();
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_set_union_empty_sets() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let set1 = Value::new_set(BTreeSet::new());
         let set2 = Value::new_set(BTreeSet::new());
@@ -765,7 +765,7 @@ mod tests {
 
     #[test]
     fn test_set_union_one_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -792,7 +792,7 @@ mod tests {
 
     #[test]
     fn test_set_union_mixed_types() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements1 = BTreeSet::new();
         elements1.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -825,7 +825,7 @@ mod tests {
 
     #[test]
     fn test_set_intersection_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create set1 = {1, 2, 3, 4}
         let mut elements1 = BTreeSet::new();
@@ -874,7 +874,7 @@ mod tests {
 
     #[test]
     fn test_set_intersection_no_common_elements() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements1 = BTreeSet::new();
         elements1.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -902,7 +902,7 @@ mod tests {
 
     #[test]
     fn test_set_intersection_empty_sets() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let set1 = Value::new_set(BTreeSet::new());
         let set2 = Value::new_set(BTreeSet::new());
@@ -923,7 +923,7 @@ mod tests {
 
     #[test]
     fn test_set_difference_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create set1 = {1, 2, 3, 4}
         let mut elements1 = BTreeSet::new();
@@ -972,7 +972,7 @@ mod tests {
 
     #[test]
     fn test_set_difference_no_overlap() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements1 = BTreeSet::new();
         elements1.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -1004,7 +1004,7 @@ mod tests {
 
     #[test]
     fn test_set_difference_empty_result() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements1 = BTreeSet::new();
         elements1.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -1029,7 +1029,7 @@ mod tests {
 
     #[test]
     fn test_set_difference_empty_sets() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let set1 = Value::new_set(BTreeSet::new());
         let set2 = Value::new_set(BTreeSet::new());
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create set1 = {1, 2}
         let mut elements1 = BTreeSet::new();
@@ -1074,7 +1074,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         // Create set1 = {1, 2, 5}
         let mut elements1 = BTreeSet::new();
@@ -1099,7 +1099,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_equal_sets() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(1.0)));
@@ -1116,7 +1116,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_empty_set() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let set1 = Value::new_set(BTreeSet::new());
 
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_both_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
 
         let set1 = Value::new_set(BTreeSet::new());
         let set2 = Value::new_set(BTreeSet::new());
@@ -1146,7 +1146,7 @@ mod tests {
 
     #[test]
     fn test_set_union_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -1157,7 +1157,7 @@ mod tests {
 
     #[test]
     fn test_set_intersection_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -1168,7 +1168,7 @@ mod tests {
 
     #[test]
     fn test_set_difference_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -1179,7 +1179,7 @@ mod tests {
 
     #[test]
     fn test_set_is_subset_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -1190,7 +1190,7 @@ mod tests {
 
     #[test]
     fn test_set_algebra_on_non_set() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_a_set = Value::Number(42.0);
         let set = Value::new_set(BTreeSet::new());
 
@@ -1213,7 +1213,7 @@ mod tests {
 
     #[test]
     fn test_set_algebra_with_non_set_argument() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let not_a_set = Value::Number(42.0);
 
@@ -1238,7 +1238,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let args = vec![set];
 
@@ -1259,7 +1259,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_with_numbers() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(1.0)));
         elements.insert(SetKey::Number(OrderedFloat(2.0)));
@@ -1292,7 +1292,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_with_strings() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::String(Rc::from("apple")));
         elements.insert(SetKey::String(Rc::from("banana")));
@@ -1332,7 +1332,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_with_booleans() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Boolean(true));
         elements.insert(SetKey::Boolean(false));
@@ -1361,7 +1361,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_mixed_types() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let mut elements = BTreeSet::new();
         elements.insert(SetKey::Number(OrderedFloat(42.0)));
         elements.insert(SetKey::String(Rc::from("hello")));
@@ -1400,7 +1400,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_wrong_arg_count() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let set = Value::new_set(BTreeSet::new());
         let extra_arg = Value::Number(42.0);
         let args = vec![set, extra_arg];
@@ -1412,7 +1412,7 @@ mod tests {
 
     #[test]
     fn test_set_to_array_on_non_set() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let not_a_set = Value::Number(42.0);
         let args = vec![not_a_set];
 

--- a/src/vm/string_functions.rs
+++ b/src/vm/string_functions.rs
@@ -262,7 +262,7 @@ mod tests {
 
     #[test]
     fn test_string_len_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello");
         let args = vec![test_str];
 
@@ -272,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_string_len_unicode() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello 🌍");
         let args = vec![test_str];
 
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn test_string_len_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let args = vec![test_str];
 
@@ -292,7 +292,7 @@ mod tests {
 
     #[test]
     fn test_substring_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let args = vec![test_str, Value::Number(0.0), Value::Number(5.0)];
 
@@ -302,7 +302,7 @@ mod tests {
 
     #[test]
     fn test_substring_middle() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let args = vec![test_str, Value::Number(6.0), Value::Number(11.0)];
 
@@ -312,7 +312,7 @@ mod tests {
 
     #[test]
     fn test_substring_negative_indices() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let args = vec![test_str, Value::Number(-5.0), Value::Number(-1.0)];
 
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn test_substring_out_of_bounds() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello");
         let args = vec![test_str, Value::Number(0.0), Value::Number(100.0)];
 
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_substring_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello");
         let args = vec![test_str, Value::Number(2.0), Value::Number(2.0)];
 
@@ -342,7 +342,7 @@ mod tests {
 
     #[test]
     fn test_substring_start_greater_than_end() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello");
         // start=5, end=0: should return empty string
         let args = vec![test_str, Value::Number(5.0), Value::Number(0.0)];
@@ -353,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_replace_basic() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let old = string!("world");
         let new = string!("rust");
@@ -365,7 +365,7 @@ mod tests {
 
     #[test]
     fn test_replace_multiple() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("foo bar foo");
         let old = string!("foo");
         let new = string!("baz");
@@ -377,7 +377,7 @@ mod tests {
 
     #[test]
     fn test_replace_not_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let old = string!("xyz");
         let new = string!("abc");
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn test_replace_empty_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let old = string!("foo");
         let new = string!("bar");
@@ -401,7 +401,7 @@ mod tests {
 
     #[test]
     fn test_replace_with_empty() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let old = string!(" ");
         let new = string!("");
@@ -413,7 +413,7 @@ mod tests {
 
     #[test]
     fn test_split_basic_comma() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("a,b,c");
         let delimiter = string!(",");
         let args = vec![test_str, delimiter];
@@ -440,7 +440,7 @@ mod tests {
 
     #[test]
     fn test_split_delimiter_not_found() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let delimiter = string!(",");
         let args = vec![test_str, delimiter];
@@ -464,7 +464,7 @@ mod tests {
 
     #[test]
     fn test_split_empty_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let delimiter = string!(",");
         let args = vec![test_str, delimiter];
@@ -488,7 +488,7 @@ mod tests {
 
     #[test]
     fn test_split_empty_delimiter() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello");
         let delimiter = string!("");
         let args = vec![test_str, delimiter];
@@ -516,7 +516,7 @@ mod tests {
 
     #[test]
     fn test_split_multiple_consecutive_delimiters() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("a,,b,,c");
         let delimiter = string!(",");
         let args = vec![test_str, delimiter];
@@ -545,7 +545,7 @@ mod tests {
 
     #[test]
     fn test_split_space_delimiter() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("hello world");
         let delimiter = string!(" ");
         let args = vec![test_str, delimiter];
@@ -571,7 +571,7 @@ mod tests {
     // Tests for String.toInt()
     #[test]
     fn test_to_int_basic_positive() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("123");
         let args = vec![test_str];
 
@@ -581,7 +581,7 @@ mod tests {
 
     #[test]
     fn test_to_int_basic_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("-456");
         let args = vec![test_str];
 
@@ -591,7 +591,7 @@ mod tests {
 
     #[test]
     fn test_to_int_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("0");
         let args = vec![test_str];
 
@@ -601,7 +601,7 @@ mod tests {
 
     #[test]
     fn test_to_int_with_whitespace() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("  789  ");
         let args = vec![test_str];
 
@@ -611,7 +611,7 @@ mod tests {
 
     #[test]
     fn test_to_int_large_number() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("9876543210");
         let args = vec![test_str];
 
@@ -621,7 +621,7 @@ mod tests {
 
     #[test]
     fn test_to_int_invalid_float() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("123.45");
         let args = vec![test_str];
 
@@ -632,7 +632,7 @@ mod tests {
 
     #[test]
     fn test_to_int_invalid_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("abc");
         let args = vec![test_str];
 
@@ -643,7 +643,7 @@ mod tests {
 
     #[test]
     fn test_to_int_empty_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let args = vec![test_str];
 
@@ -653,7 +653,7 @@ mod tests {
 
     #[test]
     fn test_to_int_mixed_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("123abc");
         let args = vec![test_str];
 
@@ -664,7 +664,7 @@ mod tests {
     // Tests for String.toFloat()
     #[test]
     fn test_to_float_basic_integer() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("123");
         let args = vec![test_str];
 
@@ -674,7 +674,7 @@ mod tests {
 
     #[test]
     fn test_to_float_basic_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("45.67");
         let args = vec![test_str];
 
@@ -684,7 +684,7 @@ mod tests {
 
     #[test]
     fn test_to_float_negative() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("-12.34");
         let args = vec![test_str];
 
@@ -694,7 +694,7 @@ mod tests {
 
     #[test]
     fn test_to_float_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("0.0");
         let args = vec![test_str];
 
@@ -704,7 +704,7 @@ mod tests {
 
     #[test]
     fn test_to_float_with_whitespace() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("  3.14  ");
         let args = vec![test_str];
 
@@ -714,7 +714,7 @@ mod tests {
 
     #[test]
     fn test_to_float_scientific_notation() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("1.23e4");
         let args = vec![test_str];
 
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn test_to_float_scientific_notation_negative_exponent() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("1.5e-2");
         let args = vec![test_str];
 
@@ -734,7 +734,7 @@ mod tests {
 
     #[test]
     fn test_to_float_no_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("42");
         let args = vec![test_str];
 
@@ -744,7 +744,7 @@ mod tests {
 
     #[test]
     fn test_to_float_leading_decimal() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!(".5");
         let args = vec![test_str];
 
@@ -754,7 +754,7 @@ mod tests {
 
     #[test]
     fn test_to_float_invalid_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("abc");
         let args = vec![test_str];
 
@@ -765,7 +765,7 @@ mod tests {
 
     #[test]
     fn test_to_float_empty_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let args = vec![test_str];
 
@@ -775,7 +775,7 @@ mod tests {
 
     #[test]
     fn test_to_float_mixed_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("12.34abc");
         let args = vec![test_str];
 
@@ -785,7 +785,7 @@ mod tests {
 
     #[test]
     fn test_to_float_infinity() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("inf");
         let args = vec![test_str];
 
@@ -795,7 +795,7 @@ mod tests {
 
     #[test]
     fn test_to_float_negative_infinity() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("-inf");
         let args = vec![test_str];
 
@@ -806,7 +806,7 @@ mod tests {
     // Tests for String.toBool()
     #[test]
     fn test_to_bool_lowercase_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("true");
         let args = vec![test_str];
 
@@ -816,7 +816,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_lowercase_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("false");
         let args = vec![test_str];
 
@@ -826,7 +826,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_uppercase_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("TRUE");
         let args = vec![test_str];
 
@@ -836,7 +836,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_uppercase_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("FALSE");
         let args = vec![test_str];
 
@@ -846,7 +846,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_mixed_case_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("TrUe");
         let args = vec![test_str];
 
@@ -856,7 +856,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_mixed_case_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("FaLsE");
         let args = vec![test_str];
 
@@ -866,7 +866,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_with_whitespace_true() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("  true  ");
         let args = vec![test_str];
 
@@ -876,7 +876,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_with_whitespace_false() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("  false  ");
         let args = vec![test_str];
 
@@ -886,7 +886,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_with_tabs_and_newlines() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("\t\ntrue\n\t");
         let args = vec![test_str];
 
@@ -896,7 +896,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_invalid_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("yes");
         let args = vec![test_str];
 
@@ -907,7 +907,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_invalid_number() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("1");
         let args = vec![test_str];
 
@@ -918,7 +918,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_invalid_zero() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("0");
         let args = vec![test_str];
 
@@ -929,7 +929,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_empty_string() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("");
         let args = vec![test_str];
 
@@ -940,7 +940,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_partial_match() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("truee");
         let args = vec![test_str];
 
@@ -950,7 +950,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_mixed_content() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("true123");
         let args = vec![test_str];
 
@@ -960,7 +960,7 @@ mod tests {
 
     #[test]
     fn test_to_bool_with_surrounding_text() {
-        let mut vm = VirtualMachine::new();
+        let mut vm = VirtualMachine::new(Vec::new());
         let test_str = string!("the answer is true");
         let args = vec![test_str];
 

--- a/src/vm/tests/basic.rs
+++ b/src/vm/tests/basic.rs
@@ -8,7 +8,7 @@ use std::assert_eq;
 
 #[test]
 fn can_create_vm() {
-    let vm = VirtualMachine::new();
+    let vm = VirtualMachine::new(Vec::new());
     assert_eq!(0, vm.call_frames.len());
     assert_eq!(0, vm.stack.len());
 }
@@ -28,7 +28,7 @@ fn can_execute_simple_arithmetics() {
     bloq.write_op_code(OpCode::Divide, 0, 0);
     bloq.write_op_code(OpCode::Return, 0, 0);
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
 
     let result = vm.run_bloq(bloq);
     assert_eq!(Result::Ok, result);
@@ -41,7 +41,7 @@ fn can_print_hello_world() {
         print "Hello World 🌍"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
 
     assert_eq!(Result::Ok, result);
@@ -53,7 +53,7 @@ fn can_print_the_answer_to_everything_times_pi() {
         print 42 * 3.14
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
 
     assert_eq!(Result::Ok, result);
@@ -66,7 +66,7 @@ fn can_run_multi_line_statements() {
         print 13
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
 
     assert_eq!(Result::Ok, result);
@@ -79,7 +79,7 @@ fn can_define_a_global_value() {
         print greeting
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
 
     assert_eq!(Result::Ok, result);
@@ -93,7 +93,7 @@ fn can_negate_numbers() {
         print -x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("-42", vm.get_output());
@@ -105,7 +105,7 @@ fn can_compare_numbers_equal() {
         print 42 == 42
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -117,7 +117,7 @@ fn can_compare_numbers_not_equal() {
         print 42 == 43
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -129,7 +129,7 @@ fn can_compare_greater_than() {
         print 43 > 42
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -141,7 +141,7 @@ fn can_compare_less_than() {
         print 41 < 42
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -153,7 +153,7 @@ fn can_use_logical_not() {
         print !false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -166,7 +166,7 @@ fn can_handle_nil() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("nil", vm.get_output());
@@ -179,7 +179,7 @@ fn can_handle_boolean_true() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -192,7 +192,7 @@ fn can_handle_boolean_false() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -204,7 +204,7 @@ fn can_handle_string_concatenation() {
         print "Hello" + " " + "World"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello World", vm.get_output());
@@ -218,7 +218,7 @@ fn can_handle_multiple_global_variables() {
         print x + y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("42", vm.get_output());
@@ -232,7 +232,7 @@ fn can_handle_complex_arithmetic() {
         print (x + y) * (x - y)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("75", vm.get_output());
@@ -244,7 +244,7 @@ fn can_handle_string_comparison() {
         print "hello" == "hello"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -256,7 +256,7 @@ fn can_handle_multiple_boolean_operations() {
         print true == !false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -268,7 +268,7 @@ fn can_handle_division_by_integers() {
         print 100 / 20
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("5", vm.get_output());
@@ -280,7 +280,7 @@ fn can_handle_float_division() {
         print 10.0 / 3.0
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3.3333333333333335", vm.get_output());
@@ -293,7 +293,7 @@ fn can_handle_negative_numbers() {
         print -x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("42", vm.get_output());
@@ -305,7 +305,7 @@ fn can_handle_boolean_arithmetic() {
         print true == true == true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -320,7 +320,7 @@ fn can_handle_complex_string_operations() {
         print greeting + " " + name + punctuation
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello World!", vm.get_output());
@@ -332,7 +332,7 @@ fn can_handle_multiple_negations() {
         print !!true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -348,7 +348,7 @@ fn can_handle_a_true_if_statement() {
         print "The end"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("The answer to everything\nThe end", vm.get_output());
@@ -364,7 +364,7 @@ fn can_handle_a_false_if_statement() {
         print "The end"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("The end", vm.get_output());
@@ -381,7 +381,7 @@ fn can_handle_a_true_if_else_statement() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("The answer to everything", vm.get_output());
@@ -400,7 +400,7 @@ fn can_handle_multiple_if_else_statements() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("The end", vm.get_output());
@@ -419,7 +419,7 @@ fn can_handle_multiple_if_else_statements_2() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("The beginning", vm.get_output());
@@ -433,7 +433,7 @@ fn can_assign_value_to_variable() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("15", vm.get_output());
@@ -447,7 +447,7 @@ fn cannot_assign_value_to_value() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::CompileError, result);
     assert_eq!(
@@ -464,7 +464,7 @@ fn cannot_access_undefined_variable() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::CompileError, result);
     assert_eq!(
@@ -484,7 +484,7 @@ fn can_loop() {
         print "Done"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n4\n5\n6\n7\n8\n9\n10\nDone", vm.get_output());
@@ -499,7 +499,7 @@ fn can_call_function() {
         greet()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello from function!", vm.get_output());
@@ -515,7 +515,7 @@ fn can_call_function_multiple_times() {
         greet()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello again!\nHello again!", vm.get_output());
@@ -536,7 +536,7 @@ fn can_calculate_fibonacci() {
         print fib(10)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let start = std::time::Instant::now();
     let result = vm.interpret(program.to_string());
     let elapsed = start.elapsed();
@@ -560,7 +560,7 @@ fn can_calculate_fibonacci_20() {
         print fib(20)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let start = std::time::Instant::now();
     let result = vm.interpret(program.to_string());
     let elapsed = start.elapsed();
@@ -581,7 +581,7 @@ fn can_handle_nested_function_calls() {
         greet()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello\nWorld", vm.get_output());
@@ -593,7 +593,7 @@ fn cannot_call_undefined_function() {
         undefined_function()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::CompileError, result);
     assert_eq!(
@@ -610,7 +610,7 @@ fn can_handle_function_with_no_body() {
         print "Done"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Done", vm.get_output());
@@ -625,7 +625,7 @@ fn can_use_modulo_operator() {
         print 4 % 5
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n1\n0\n4", vm.get_output());
@@ -644,7 +644,7 @@ fn can_use_struct() {
         print p.y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3\n4", vm.get_output());
@@ -653,7 +653,7 @@ fn can_use_struct() {
 #[test]
 fn can_call_native_function_directly() {
     // Test calling a native function directly (not through VM bytecode)
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
 
     let args = vec![Value::Number(5.0), Value::Number(3.0)];
     let result = native_functions::native_add(&mut vm, &args);
@@ -667,7 +667,7 @@ fn can_call_native_function_directly() {
 
 #[test]
 fn native_function_rejects_wrong_arity() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
 
     let args = vec![Value::Number(5.0)];
     let result = native_functions::native_add(&mut vm, &args);
@@ -678,7 +678,7 @@ fn native_function_rejects_wrong_arity() {
 
 #[test]
 fn native_function_rejects_wrong_types() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
 
     let args = vec![Value::Number(5.0), Value::Boolean(true)];
     let result = native_functions::native_add(&mut vm, &args);
@@ -710,7 +710,7 @@ fn test_logical_and_true_true() {
         print true && true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -722,7 +722,7 @@ fn test_logical_and_true_false() {
         print true && false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -734,7 +734,7 @@ fn test_logical_and_false_true() {
         print false && true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -746,7 +746,7 @@ fn test_logical_and_false_false() {
         print false && false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -758,7 +758,7 @@ fn test_logical_or_true_true() {
         print true || true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -770,7 +770,7 @@ fn test_logical_or_true_false() {
         print true || false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -782,7 +782,7 @@ fn test_logical_or_false_true() {
         print false || true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -794,7 +794,7 @@ fn test_logical_or_false_false() {
         print false || false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -806,7 +806,7 @@ fn test_logical_operators_with_comparisons() {
         print 5 > 3 && 10 < 20
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -820,7 +820,7 @@ fn test_logical_operators_with_variables() {
         print x && y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -834,7 +834,7 @@ fn test_logical_or_with_variables() {
         print x || y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -846,7 +846,7 @@ fn test_logical_precedence_or_and() {
         print false || true && false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Should parse as: false || (true && false)
@@ -861,7 +861,7 @@ fn test_logical_precedence_and_or() {
         print true && false || true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Should parse as: (true && false) || true
@@ -876,7 +876,7 @@ fn test_logical_precedence_with_parens() {
         print (false || true) && false
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // (false || true) = true
@@ -894,7 +894,7 @@ fn test_logical_and_short_circuit() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // x should still be 10 because the right side of && should not evaluate
@@ -911,7 +911,7 @@ fn test_logical_or_short_circuit() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // x should still be 10 because the right side of || should not evaluate
@@ -927,7 +927,7 @@ fn test_logical_complex_expression() {
         print (a || b) && c
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // (true || false) = true
@@ -941,7 +941,7 @@ fn test_logical_with_not() {
         print !false && true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // !false = true
@@ -955,7 +955,7 @@ fn test_logical_chained_and() {
         print true && true && true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -967,7 +967,7 @@ fn test_logical_chained_and_with_false() {
         print true && false && true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -979,7 +979,7 @@ fn test_logical_chained_or() {
         print false || false || true
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -995,7 +995,7 @@ fn test_logical_in_if_statement() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Both positive", vm.get_output());
@@ -1014,7 +1014,7 @@ fn test_logical_in_while_loop() {
         print y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3\n0", vm.get_output());
@@ -1027,7 +1027,7 @@ fn test_logical_with_equality() {
         print x == 5 && x > 0
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -1043,7 +1043,7 @@ fn test_logical_all_operators_combined() {
         print (a && b) || (c && !d)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // (true && false) = false
@@ -1064,7 +1064,7 @@ fn test_empty_map_creation() {
         print m
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("{}", vm.get_output());
@@ -1077,7 +1077,7 @@ fn test_map_creation_with_string_keys() {
         print m
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     let output = vm.get_output();
@@ -1092,7 +1092,7 @@ fn test_map_access_string_key() {
         print m["name"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice", vm.get_output());
@@ -1105,7 +1105,7 @@ fn test_map_access_missing_key_returns_nil() {
         print m["missing"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("nil", vm.get_output());
@@ -1119,7 +1119,7 @@ fn test_map_set_new_value() {
         print m["age"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("30", vm.get_output());
@@ -1133,7 +1133,7 @@ fn test_map_update_existing_value() {
         print m["name"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Bob", vm.get_output());
@@ -1146,7 +1146,7 @@ fn test_map_with_number_keys() {
         print m[2]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("two", vm.get_output());
@@ -1160,7 +1160,7 @@ fn test_map_with_boolean_keys() {
         print m[false]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("yes\nno", vm.get_output());
@@ -1175,7 +1175,7 @@ fn test_map_with_mixed_key_types() {
         print m[true]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice\nanswer\nyes", vm.get_output());
@@ -1190,7 +1190,7 @@ fn test_map_with_mixed_value_types() {
         print m["nil"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("42\ntrue\nnil", vm.get_output());
@@ -1203,7 +1203,7 @@ fn test_map_nested_in_map() {
         print m["inner"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("{x: 10}", vm.get_output());
@@ -1217,7 +1217,7 @@ fn test_map_assignment_returns_value() {
         print result
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("42", vm.get_output());
@@ -1231,7 +1231,7 @@ fn test_map_in_variable_assignment() {
         print m2["x"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1", vm.get_output());
@@ -1244,7 +1244,7 @@ fn test_map_in_expression() {
         print m["x"] + m["y"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("30", vm.get_output());
@@ -1258,7 +1258,7 @@ fn test_map_key_evaluation() {
         print m[key]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1", vm.get_output());
@@ -1272,7 +1272,7 @@ fn test_map_dynamic_key() {
         print m[x + 1]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("two", vm.get_output());
@@ -1287,7 +1287,7 @@ fn test_map_get_method_existing_key() {
         print m.get("name")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice", vm.get_output());
@@ -1300,7 +1300,7 @@ fn test_map_get_method_nonexistent_key() {
         print m.get("missing")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("nil", vm.get_output());
@@ -1313,7 +1313,7 @@ fn test_map_get_method_number_key() {
         print m.get(42)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("answer", vm.get_output());
@@ -1326,7 +1326,7 @@ fn test_map_size_method_empty() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0", vm.get_output());
@@ -1339,7 +1339,7 @@ fn test_map_size_method_with_entries() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3", vm.get_output());
@@ -1352,7 +1352,7 @@ fn test_map_has_method_existing_key() {
         print m.has("name")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -1365,7 +1365,7 @@ fn test_map_has_method_nonexistent_key() {
         print m.has("missing")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("false", vm.get_output());
@@ -1378,7 +1378,7 @@ fn test_map_has_method_boolean_key() {
         print m.has(true)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true", vm.get_output());
@@ -1393,7 +1393,7 @@ fn test_map_remove_method_existing_key() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice\n1", vm.get_output());
@@ -1408,7 +1408,7 @@ fn test_map_remove_method_nonexistent_key() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("nil\n1", vm.get_output());
@@ -1422,7 +1422,7 @@ fn test_map_keys_method_empty() {
         print keys
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[]", vm.get_output());
@@ -1436,7 +1436,7 @@ fn test_map_keys_method_with_entries() {
         print keys
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Note: HashMap order is not guaranteed, so we just check it's an array with 2 elements
@@ -1452,7 +1452,7 @@ fn test_map_values_method_empty() {
         print values
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[]", vm.get_output());
@@ -1466,7 +1466,7 @@ fn test_map_values_method_with_entries() {
         print values
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Note: HashMap order is not guaranteed, so we just check it's an array with 2 elements
@@ -1482,7 +1482,7 @@ fn test_map_entries_method_empty() {
         print entries
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[]", vm.get_output());
@@ -1496,7 +1496,7 @@ fn test_map_entries_method_with_entries() {
         print entries
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Note: HashMap order is not guaranteed, so we just check it's an array
@@ -1515,7 +1515,7 @@ fn test_map_chained_operations() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("true\n2\n3\n2", vm.get_output());
@@ -1529,7 +1529,7 @@ fn test_map_keys_with_different_types() {
         print keys
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Just verify it returns an array
@@ -1547,7 +1547,7 @@ fn test_map_method_after_modification() {
         print m.has("b")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3\ntrue", vm.get_output());
@@ -1562,7 +1562,7 @@ fn test_map_remove_then_size() {
         print m.has("y")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("2\nfalse", vm.get_output());
@@ -1576,7 +1576,7 @@ fn test_map_get_and_bracket_equivalence() {
         print m["key"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("value\nvalue", vm.get_output());
@@ -1591,7 +1591,7 @@ fn test_map_values_reflect_changes() {
         print values
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     // Verify it's an array with 3 elements
@@ -1613,7 +1613,7 @@ fn test_map_with_string_values() {
         print messages.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Hello\nGoodbye\nThank you\n3", vm.get_output());
@@ -1635,7 +1635,7 @@ fn test_map_iteration_with_modification() {
         print m["c"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n11\n12\n13", vm.get_output());
@@ -1656,7 +1656,7 @@ fn test_nested_map_access_chain() {
         print profile["name"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice", vm.get_output());
@@ -1691,7 +1691,7 @@ fn test_map_with_conditional_logic() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("Alice: A\nBob: F\nCharlie: B", vm.get_output());
@@ -1708,7 +1708,7 @@ fn test_map_direct_value_access() {
         print x_val + y_val + z_val
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("60", vm.get_output());
@@ -1735,7 +1735,7 @@ fn test_map_as_function_parameter() {
         print m2.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n3", vm.get_output());
@@ -1753,7 +1753,7 @@ fn test_map_with_computed_keys() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("100\n200\n2", vm.get_output());
@@ -1778,7 +1778,7 @@ fn test_map_update_in_loop() {
         print m["c"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n2\n4\n6", vm.get_output());
@@ -1799,7 +1799,7 @@ fn test_map_multiple_removes() {
         print m.has("d")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("4\n3\n2\nfalse\ntrue\nfalse\ntrue", vm.get_output());
@@ -1827,7 +1827,7 @@ fn test_map_with_struct_values() {
         print unit.y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0\n0\n1\n1", vm.get_output());
@@ -1842,7 +1842,7 @@ fn test_map_boolean_key_expressions() {
         print m[x < 3]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("yes\nno", vm.get_output());
@@ -1864,7 +1864,7 @@ fn test_map_chaining_operations() {
         print m.has("c")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3\n2\ntrue\nfalse\ntrue", vm.get_output());
@@ -1892,7 +1892,7 @@ fn test_map_empty_to_full_lifecycle() {
         print m.size()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0\n[]\n1\n3\n2\n0", vm.get_output());
@@ -1916,7 +1916,7 @@ fn test_map_in_recursive_function() {
         print result[3]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n4\n9", vm.get_output());
@@ -1933,7 +1933,7 @@ fn test_array_literal_empty() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[]", vm.get_output());
@@ -1946,7 +1946,7 @@ fn test_array_literal_single_element() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[42]", vm.get_output());
@@ -1959,7 +1959,7 @@ fn test_array_literal_multiple_elements() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, 2, 3]", vm.get_output());
@@ -1972,7 +1972,7 @@ fn test_array_literal_mixed_types() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, hello, true, nil]", vm.get_output());
@@ -1987,7 +1987,7 @@ fn test_array_indexing_positive() {
         print arr[2]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("10\n20\n30", vm.get_output());
@@ -2002,7 +2002,7 @@ fn test_array_indexing_negative() {
         print arr[-3]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("30\n20\n10", vm.get_output());
@@ -2020,7 +2020,7 @@ fn test_array_index_assignment() {
         print arr[2]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("10\n20\n30", vm.get_output());
@@ -2036,7 +2036,7 @@ fn test_array_index_assignment_negative() {
         print arr[2]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("88\n99", vm.get_output());
@@ -2050,7 +2050,7 @@ fn test_array_push() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, 2, 3, 4]", vm.get_output());
@@ -2066,7 +2066,7 @@ fn test_array_push_multiple() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, 2, 3]", vm.get_output());
@@ -2081,7 +2081,7 @@ fn test_array_pop() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("3\n[1, 2]", vm.get_output());
@@ -2095,7 +2095,7 @@ fn test_array_pop_empty() {
         print result
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("nil", vm.get_output());
@@ -2112,7 +2112,7 @@ fn test_array_length() {
         print arr3.length()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0\n1\n3", vm.get_output());
@@ -2129,7 +2129,7 @@ fn test_array_length_after_push() {
         print arr.length()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("2\n3\n4", vm.get_output());
@@ -2146,7 +2146,7 @@ fn test_array_length_after_pop() {
         print arr.length()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("4\n3\n2", vm.get_output());
@@ -2159,7 +2159,7 @@ fn test_array_nested() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[[1, 2], [3, 4]]", vm.get_output());
@@ -2177,7 +2177,7 @@ fn test_array_nested_access() {
         print inner2[1]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n4", vm.get_output());
@@ -2192,7 +2192,7 @@ fn test_array_nested_modification() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[[99, 2], [3, 4]]", vm.get_output());
@@ -2208,7 +2208,7 @@ fn test_array_with_variables() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[10, 20, 30]", vm.get_output());
@@ -2221,7 +2221,7 @@ fn test_array_with_expressions() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[2, 6, 5]", vm.get_output());
@@ -2235,7 +2235,7 @@ fn test_array_in_expression() {
         print sum
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("60", vm.get_output());
@@ -2249,7 +2249,7 @@ fn test_array_in_variable_assignment() {
         print arr2
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, 2, 3]", vm.get_output());
@@ -2264,7 +2264,7 @@ fn test_array_dynamic_index() {
         print arr[i + 1]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("20\n30", vm.get_output());
@@ -2279,7 +2279,7 @@ fn test_array_assignment_returns_value() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("99\n[1, 99, 3]", vm.get_output());
@@ -2308,7 +2308,7 @@ fn test_array_as_function_parameter() {
         print arr2[0]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n99", vm.get_output());
@@ -2339,7 +2339,7 @@ fn test_array_with_conditional_logic() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("B\nA\nC", vm.get_output());
@@ -2356,7 +2356,7 @@ fn test_array_in_loop() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3", vm.get_output());
@@ -2375,7 +2375,7 @@ fn test_array_accumulation() {
         print sum
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("15", vm.get_output());
@@ -2403,7 +2403,7 @@ fn test_array_push_pop_lifecycle() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0\n3\n[1, 2, 3]\n2\n[1, 2]\n0\n[]", vm.get_output());
@@ -2423,7 +2423,7 @@ fn test_array_with_map_values() {
         print second["y"]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n4", vm.get_output());
@@ -2445,7 +2445,7 @@ fn test_map_with_array_values() {
         print strings[1]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n3\nb", vm.get_output());
@@ -2463,7 +2463,7 @@ fn test_array_build_with_loop() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[1, 4, 9, 16, 25]", vm.get_output());
@@ -2480,7 +2480,7 @@ fn test_array_reverse_with_negative_indices() {
         print arr[-5]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("5\n4\n3\n2\n1", vm.get_output());
@@ -2503,7 +2503,7 @@ fn test_array_modification_in_function() {
         print result
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("[2, 4, 6]", vm.get_output());
@@ -2521,7 +2521,7 @@ fn test_array_chained_operations() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("5\n4\n[1, 2, 3, 4]", vm.get_output());
@@ -2546,7 +2546,7 @@ fn test_array_with_struct_values() {
         print p2.y
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n2\n3\n4", vm.get_output());
@@ -2576,7 +2576,7 @@ fn test_array_empty_to_full_lifecycle() {
         print arr
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0\n1\n10\n3\n[10, 99, 30]\n0\n[]", vm.get_output());
@@ -2600,7 +2600,7 @@ fn test_array_large_size() {
         print arr[299]
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("300\n0\n255\n256\n299", vm.get_output());
@@ -2627,7 +2627,7 @@ fn test_array_literal_large_size() {
         array_literal
     );
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program);
     assert_eq!(Result::Ok, result);
     assert_eq!("300\n0\n255\n256\n299", vm.get_output());

--- a/src/vm/tests/math_errors.rs
+++ b/src/vm/tests/math_errors.rs
@@ -10,7 +10,7 @@ fn test_math_abs_with_string() {
         print Math.abs("string")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -21,7 +21,7 @@ fn test_math_abs_with_boolean() {
         print Math.abs(true)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -32,7 +32,7 @@ fn test_math_abs_with_nil() {
         print Math.abs(nil)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -43,7 +43,7 @@ fn test_math_abs_no_args() {
         print Math.abs()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -54,7 +54,7 @@ fn test_math_abs_too_many_args() {
         print Math.abs(1, 2)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -69,7 +69,7 @@ fn test_math_floor_with_string() {
         print Math.floor("hello")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -80,7 +80,7 @@ fn test_math_floor_with_boolean() {
         print Math.floor(false)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -91,7 +91,7 @@ fn test_math_floor_with_nil() {
         print Math.floor(nil)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -102,7 +102,7 @@ fn test_math_floor_no_args() {
         print Math.floor()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -113,7 +113,7 @@ fn test_math_floor_too_many_args() {
         print Math.floor(1.5, 2.5)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -128,7 +128,7 @@ fn test_math_ceil_with_string() {
         print Math.ceil("world")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -139,7 +139,7 @@ fn test_math_ceil_with_boolean() {
         print Math.ceil(true)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -150,7 +150,7 @@ fn test_math_ceil_with_nil() {
         print Math.ceil(nil)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -161,7 +161,7 @@ fn test_math_ceil_no_args() {
         print Math.ceil()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -172,7 +172,7 @@ fn test_math_ceil_too_many_args() {
         print Math.ceil(1.5, 2.5)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -187,7 +187,7 @@ fn test_math_sqrt_with_negative() {
         print Math.sqrt(-1)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -198,7 +198,7 @@ fn test_math_sqrt_with_string() {
         print Math.sqrt("42")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -209,7 +209,7 @@ fn test_math_sqrt_with_boolean() {
         print Math.sqrt(false)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -220,7 +220,7 @@ fn test_math_sqrt_with_nil() {
         print Math.sqrt(nil)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -231,7 +231,7 @@ fn test_math_sqrt_no_args() {
         print Math.sqrt()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -242,7 +242,7 @@ fn test_math_sqrt_too_many_args() {
         print Math.sqrt(4, 9)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -253,7 +253,7 @@ fn test_math_sqrt_large_negative() {
         print Math.sqrt(-100)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -268,7 +268,7 @@ fn test_math_min_no_args() {
         print Math.min()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -279,7 +279,7 @@ fn test_math_min_with_string_first() {
         print Math.min("hello", 2, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -290,7 +290,7 @@ fn test_math_min_with_string_middle() {
         print Math.min(1, "hello", 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -301,7 +301,7 @@ fn test_math_min_with_string_last() {
         print Math.min(1, 2, "hello")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -312,7 +312,7 @@ fn test_math_min_with_boolean() {
         print Math.min(1, true, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -323,7 +323,7 @@ fn test_math_min_with_nil() {
         print Math.min(1, nil, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -334,7 +334,7 @@ fn test_math_min_all_non_numbers() {
         print Math.min("a", "b", "c")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -345,7 +345,7 @@ fn test_math_min_mixed_types() {
         print Math.min(1, "hello", true, nil, 5)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -360,7 +360,7 @@ fn test_math_max_no_args() {
         print Math.max()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -371,7 +371,7 @@ fn test_math_max_with_string_first() {
         print Math.max("hello", 2, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -382,7 +382,7 @@ fn test_math_max_with_string_middle() {
         print Math.max(1, "hello", 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -393,7 +393,7 @@ fn test_math_max_with_string_last() {
         print Math.max(1, 2, "hello")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -404,7 +404,7 @@ fn test_math_max_with_boolean() {
         print Math.max(1, false, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -415,7 +415,7 @@ fn test_math_max_with_nil() {
         print Math.max(1, nil, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -426,7 +426,7 @@ fn test_math_max_all_non_numbers() {
         print Math.max(true, false, true)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -437,7 +437,7 @@ fn test_math_max_mixed_types() {
         print Math.max(1, "world", false, nil, 5)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -453,7 +453,7 @@ fn test_math_error_in_expression() {
         print x
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -467,7 +467,7 @@ fn test_math_error_in_function_call() {
         print test()
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -480,7 +480,7 @@ fn test_math_error_in_if_condition() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -493,7 +493,7 @@ fn test_math_error_in_while_condition() {
         }
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -506,7 +506,7 @@ fn test_math_error_does_not_crash_vm() {
         print "After error (unreachable)"
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
     // VM should print "Before error" but not crash
@@ -521,7 +521,7 @@ fn test_multiple_math_errors() {
         print Math.sqrt(-1)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     // Should fail on the first error
     assert_eq!(Result::RuntimeError, result);
@@ -534,7 +534,7 @@ fn test_math_error_with_variables() {
         print Math.floor(x)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -545,7 +545,7 @@ fn test_math_error_with_expression_arg() {
         print Math.abs(5 + "string")
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -556,7 +556,7 @@ fn test_math_nested_error() {
         print Math.abs(Math.sqrt(-5))
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -567,7 +567,7 @@ fn test_math_min_max_combined_error() {
         print Math.min(Math.max(), 5)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::RuntimeError, result);
 }
@@ -587,7 +587,7 @@ fn test_math_functions_dont_error_on_valid_input() {
         print Math.max(1, 2, 3)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("5\n3\n3\n4\n1\n3", vm.get_output());
@@ -599,7 +599,7 @@ fn test_math_sqrt_zero_is_valid() {
         print Math.sqrt(0)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("0", vm.get_output());
@@ -612,7 +612,7 @@ fn test_math_single_arg_functions_valid() {
         print Math.max(42)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("42\n42", vm.get_output());

--- a/src/vm/tests/math_variadic.rs
+++ b/src/vm/tests/math_variadic.rs
@@ -8,7 +8,7 @@ fn test_math_min_variadic() {
         print Math.min(42)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("1\n3\n42", vm.get_output());
@@ -22,7 +22,7 @@ fn test_math_max_variadic() {
         print Math.max(42)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("8\n7\n42", vm.get_output());
@@ -35,7 +35,7 @@ fn test_math_min_max_negative() {
         print Math.max(-5, -2, -8)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("-8\n-2", vm.get_output());
@@ -48,7 +48,7 @@ fn test_math_min_max_mixed() {
         print Math.max(10, -3, 5, -10)
         "#;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(program.to_string());
     assert_eq!(Result::Ok, result);
     assert_eq!("-10\n10", vm.get_output());

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -12,7 +12,7 @@ impl NeonVM {
     pub fn new() -> Self {
         console_error_panic_hook::set_once();
         NeonVM {
-            vm: VirtualMachine::new(),
+            vm: VirtualMachine::new(Vec::new()),
         }
     }
 
@@ -59,7 +59,7 @@ struct InterpretResult {
 #[wasm_bindgen]
 pub fn interpret_once(source: String) -> JsValue {
     console_error_panic_hook::set_once();
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(source);
 
     match result {

--- a/test_semantic_args.rs
+++ b/test_semantic_args.rs
@@ -1,0 +1,7 @@
+use neon::compiler::semantic::SemanticAnalyzer;
+
+fn main() {
+    let analyzer = SemanticAnalyzer::new();
+    // Check if args is defined
+    println!("SemanticAnalyzer created");
+}

--- a/tests/file_io_test.rs
+++ b/tests/file_io_test.rs
@@ -25,7 +25,7 @@ fn cleanup_test_file(path: &PathBuf) {
 
 #[test]
 fn test_file_constructor_from_neon() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = r#"
         var f = File("test.txt")
         print f
@@ -44,7 +44,7 @@ fn test_file_read_basic() {
     let test_file = create_test_file("read_basic.txt", "Hello, World!");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -66,7 +66,7 @@ fn test_file_read_multiline() {
     let test_file = create_test_file("read_multiline.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -87,7 +87,7 @@ fn test_file_read_empty_file() {
     let test_file = create_test_file("read_empty.txt", "");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -112,7 +112,7 @@ fn test_file_read_unicode() {
     let test_file = create_test_file("read_unicode.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -130,7 +130,7 @@ fn test_file_read_unicode() {
 
 #[test]
 fn test_file_read_not_found() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = r#"
         var f = File("/nonexistent/path/to/file.txt")
         var content = f.read()
@@ -148,7 +148,7 @@ fn test_file_read_lines_basic() {
     let test_file = create_test_file("readlines_basic.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -176,7 +176,7 @@ fn test_file_read_lines_with_empty_lines() {
     let test_file = create_test_file("readlines_empty.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -204,7 +204,7 @@ fn test_file_read_lines_crlf() {
     let test_file = create_test_file("readlines_crlf.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -231,7 +231,7 @@ fn test_file_read_lines_empty_file() {
     let test_file = create_test_file("readlines_empty_file.txt", "");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -252,7 +252,7 @@ fn test_file_read_lines_single_line_no_newline() {
     let test_file = create_test_file("readlines_single.txt", "Single line");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -272,7 +272,7 @@ fn test_file_read_lines_single_line_no_newline() {
 
 #[test]
 fn test_file_read_lines_not_found() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = r#"
         var f = File("/nonexistent/path/to/file.txt")
         var lines = f.readLines()
@@ -293,7 +293,7 @@ fn test_file_write_basic() {
     // Ensure file doesn't exist
     let _ = fs::remove_file(&test_file);
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         f.write("Hello from Neon!")
@@ -329,7 +329,7 @@ fn test_file_write_multiline() {
         file.write_all(temp_content.as_bytes()).unwrap();
     }
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -355,7 +355,7 @@ fn test_file_write_empty_content() {
     // Ensure file doesn't exist
     let _ = fs::remove_file(&test_file);
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         f.write("")
@@ -377,7 +377,7 @@ fn test_file_write_file_already_exists() {
     let test_file = create_test_file("write_exists.txt", "Existing content");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         f.write("New content")
@@ -397,7 +397,7 @@ fn test_file_write_file_already_exists() {
 
 #[test]
 fn test_file_write_invalid_directory() {
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = r#"
         var f = File("/nonexistent/directory/file.txt")
         f.write("content")
@@ -418,7 +418,7 @@ fn test_file_end_to_end_write_then_read() {
     // Ensure file doesn't exist
     let _ = fs::remove_file(&test_file);
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f1 = File("{}")
         f1.write("Test content for end-to-end")
@@ -452,7 +452,7 @@ fn test_file_end_to_end_write_then_read_lines() {
         file.write_all(b"First\nSecond\nThird").unwrap();
     }
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()
@@ -479,7 +479,7 @@ fn test_file_multiple_operations_same_file_object() {
     let test_file = create_test_file("multiple_ops.txt", "Line 1\nLine 2\nLine 3");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var content = f.read()
@@ -504,7 +504,7 @@ fn test_file_constructor_with_variable_path() {
     let test_file = create_test_file("var_path.txt", "Content");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var path = "{}"
         var f = File(path)
@@ -526,7 +526,7 @@ fn test_file_in_function() {
     let test_file = create_test_file("in_function.txt", "Function test");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         fn readFile(path) {{
             var f = File(path)
@@ -551,7 +551,7 @@ fn test_file_read_lines_in_function() {
     let test_file = create_test_file("readlines_function.txt", "A\nB\nC");
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         fn getLines(path) {{
             var f = File(path)
@@ -584,7 +584,7 @@ fn test_file_write_in_function() {
     // Ensure file doesn't exist
     let _ = fs::remove_file(&test_file);
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         fn writeFile(path, content) {{
             var f = File(path)
@@ -611,7 +611,7 @@ fn test_file_practical_example_process_lines() {
     let test_file = create_test_file("process_lines.txt", test_content);
     let file_path = test_file.to_str().unwrap();
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let source = format!(r#"
         var f = File("{}")
         var lines = f.readLines()

--- a/tests/neon_scripts.rs
+++ b/tests/neon_scripts.rs
@@ -60,7 +60,7 @@ fn run_neon_script(path: &Path) -> datatest_stable::Result<()> {
         )
     })?;
 
-    let mut vm = VirtualMachine::new();
+    let mut vm = VirtualMachine::new(Vec::new());
     let result = vm.interpret(script.to_string());
 
     assert_eq!(

--- a/tests/scripts/args_full_test.n
+++ b/tests/scripts/args_full_test.n
@@ -1,0 +1,14 @@
+// Comprehensive test for command-line arguments
+// Expected:
+// true
+// 0
+// true
+
+// Test that args is an array
+print args.length() >= 0
+
+// Test length method
+print args.length()
+
+// Test that empty args works correctly
+print args.length() == 0

--- a/tests/scripts/args_test.n
+++ b/tests/scripts/args_test.n
@@ -1,0 +1,4 @@
+// Test command-line arguments
+// Expected:
+// 0
+print args.length()


### PR DESCRIPTION
## Summary

Adds access to command-line arguments via global `args` array.

## Usage
```bash
neon script.neon arg1 arg2 arg3
```

```neon
print args.length()  // 3
print args[0]        // "arg1"
for (arg in args) {
    print arg
}
```

## Implementation
- Modified main.rs to capture CLI args
- Pass args to VM as global array
- Register args in semantic analyzer
- Add sentinel for codegen/VM dispatch

## Tests
- 765 tests passing
- Integration tests included