### PR TITLE
Remove class keyword from language

### DIFF
--- a/src/compiler/parser.rs
+++ b/src/compiler/parser.rs
@@ -257,8 +257,7 @@ impl Parser {
                 return;
             }
             match self.current_token.token_type {
-                TokenType::Class
-                | TokenType::Fn
+                TokenType::Fn
                 | TokenType::Struct
                 | TokenType::Val
                 | TokenType::Var

--- a/src/compiler/scanner.rs
+++ b/src/compiler/scanner.rs
@@ -298,16 +298,7 @@ impl Scanner {
         match chr {
             'a' => self.check_keyword(1, 2, "nd", TokenType::And),
             'b' => self.check_keyword(1, 4, "reak", TokenType::Break),
-            'c' => {
-                if self.current - self.start > 1 {
-                    return match self.source[self.start + 1] {
-                        'l' => self.check_keyword(2, 3, "ass", TokenType::Class),
-                        'o' => self.check_keyword(2, 6, "ntinue", TokenType::Continue),
-                        _ => TokenType::Identifier,
-                    };
-                }
-                TokenType::Identifier
-            }
+            'c' => self.check_keyword(1, 7, "ontinue", TokenType::Continue),
             'e' => self.check_keyword(1, 3, "lse", TokenType::Else),
             'i' => {
                 if self.current - self.start > 1 {

--- a/src/compiler/token.rs
+++ b/src/compiler/token.rs
@@ -42,7 +42,6 @@ pub(crate) enum TokenType {
 
     And,
     Break,
-    Class,
     Continue,
     Else,
     False,


### PR DESCRIPTION
## Summary

Removes the reserved `class` keyword from the Neon language. The keyword was recognized by the lexer but never implemented.

## Rationale

Neon will use Rust-style structs with `impl` traits instead of traditional classes, making the `class` keyword unnecessary and potentially confusing.

## Changes

- Remove `Class` variant from `TokenType` enum in `src/compiler/token.rs`
- Remove "class" keyword recognition from scanner in `src/compiler/scanner.rs`
- Remove `TokenType::Class` from parser error recovery in `src/compiler/parser.rs`

## Testing

- All 638 tests pass
- Cargo clippy passes with no warnings
- The word "class" is now available as a regular identifier

## Impact

No breaking changes - the keyword was never implemented, so no valid Neon code uses it.