### PR TITLE
Add support for hexadecimal, binary, and octal literals

### DIFF
--- a/src/compiler/tests/parser.rs
+++ b/src/compiler/tests/parser.rs
@@ -31,6 +31,102 @@ fn test_parse_binary_expression() {
 }
 
 #[test]
+fn test_parse_hex_number() {
+    let mut parser = Parser::new("0xFF\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 255.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
+fn test_parse_binary_number() {
+    let mut parser = Parser::new("0b1010\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 10.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
+fn test_parse_octal_number() {
+    let mut parser = Parser::new("0o755\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 493.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
+fn test_parse_number_with_underscores() {
+    let mut parser = Parser::new("1_000_000\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 1_000_000.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
+fn test_parse_hex_with_underscores() {
+    let mut parser = Parser::new("0xFF_FF\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 65535.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
+fn test_parse_binary_with_underscores() {
+    let mut parser = Parser::new("0b1111_0000\n");
+    let result = parser.parse();
+    assert!(result.is_ok());
+    let stmts = result.unwrap();
+    assert_eq!(stmts.len(), 1);
+    match &stmts[0] {
+        Stmt::Expression { expr, .. } => match expr {
+            Expr::Number { value, .. } => assert_eq!(*value, 240.0),
+            _ => panic!("Expected Number expression"),
+        },
+        _ => panic!("Expected Expression statement"),
+    }
+}
+
+#[test]
 fn test_parse_function() {
     let mut parser = Parser::new("fn foo(a, b) {\n  print(a)\n}\n");
     let result = parser.parse();

--- a/src/compiler/tests/scanner.rs
+++ b/src/compiler/tests/scanner.rs
@@ -151,3 +151,168 @@ fn can_scan_minusminus_operator() {
     assert_eq!(x[1].token, "--");
     assert_eq!(x[2].token_type, TokenType::Eof);
 }
+
+#[test]
+fn can_scan_hexadecimal_lowercase() {
+    let scanner = Scanner::new("0xff");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0xff");
+}
+
+#[test]
+fn can_scan_hexadecimal_uppercase() {
+    let scanner = Scanner::new("0XFF");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0XFF");
+}
+
+#[test]
+fn can_scan_hexadecimal_mixed_case() {
+    let scanner = Scanner::new("0xAbCdEf");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0xAbCdEf");
+}
+
+#[test]
+fn can_scan_binary_literal() {
+    let scanner = Scanner::new("0b1010");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0b1010");
+}
+
+#[test]
+fn can_scan_binary_uppercase() {
+    let scanner = Scanner::new("0B11110000");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0B11110000");
+}
+
+#[test]
+fn can_scan_octal_literal() {
+    let scanner = Scanner::new("0o755");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0o755");
+}
+
+#[test]
+fn can_scan_octal_uppercase() {
+    let scanner = Scanner::new("0O77");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0O77");
+}
+
+#[test]
+fn can_scan_decimal_with_underscores() {
+    let scanner = Scanner::new("1_000_000");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "1_000_000");
+}
+
+#[test]
+fn can_scan_hex_with_underscores() {
+    let scanner = Scanner::new("0xFF_FF");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0xFF_FF");
+}
+
+#[test]
+fn can_scan_binary_with_underscores() {
+    let scanner = Scanner::new("0b1111_0000");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0b1111_0000");
+}
+
+#[test]
+fn can_scan_octal_with_underscores() {
+    let scanner = Scanner::new("0o7_5_5");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "0o7_5_5");
+}
+
+#[test]
+fn can_scan_float_with_underscores() {
+    let scanner = Scanner::new("1_234.567_89");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens.len(), 2);
+    assert_eq!(tokens[0].token_type, TokenType::Number);
+    assert_eq!(tokens[0].token, "1_234.567_89");
+}
+
+#[test]
+fn rejects_invalid_binary_digit() {
+    let scanner = Scanner::new("0b123");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens[0].token_type, TokenType::Error);
+    assert!(tokens[0].token.contains("Invalid digit in binary literal"));
+}
+
+#[test]
+fn rejects_invalid_octal_digit() {
+    let scanner = Scanner::new("0o89");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens[0].token_type, TokenType::Error);
+    assert!(tokens[0].token.contains("Invalid digit in octal literal"));
+}
+
+#[test]
+fn rejects_empty_hex_literal() {
+    let scanner = Scanner::new("0x");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens[0].token_type, TokenType::Error);
+    assert!(tokens[0].token.contains("requires at least one digit"));
+}
+
+#[test]
+fn rejects_empty_binary_literal() {
+    let scanner = Scanner::new("0b");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens[0].token_type, TokenType::Error);
+    assert!(tokens[0].token.contains("requires at least one digit"));
+}
+
+#[test]
+fn rejects_trailing_underscore_in_decimal() {
+    let scanner = Scanner::new("123_");
+    let tokens = collect_tokens(scanner);
+
+    assert_eq!(tokens[0].token_type, TokenType::Error);
+    assert!(tokens[0].token.contains("underscore"));
+}

--- a/tests/scripts/number_literal_formats.n
+++ b/tests/scripts/number_literal_formats.n
@@ -1,0 +1,39 @@
+// Expected:
+// 255
+// 255
+// 10
+// 240
+// 493
+// 63
+// 1000000
+// 65535
+// 240
+// 493
+// true
+// true
+
+// Hexadecimal literals
+print(0xFF)
+print(0XFF)
+
+// Binary literals
+print(0b1010)
+print(0b11110000)
+
+// Octal literals
+print(0o755)
+print(0O77)
+
+// Underscore separators
+print(1_000_000)
+print(0xFF_FF)
+print(0b1111_0000)
+print(0o7_5_5)
+
+// Use in expressions
+val mask = 0xFF
+print(mask == 255)
+
+// Use with bitwise operators
+val flags = 0b1010 | 0b0101
+print(flags == 15)


### PR DESCRIPTION
Support number literals with 0x, 0b, and 0o prefixes, and allow underscores as digit separators in all numeric formats. Update scanner to tokenize these formats and parser to convert them to decimal values.